### PR TITLE
Improve Article Edit page responsiveness across mobile and desktop

### DIFF
--- a/src/frontend/pages/ArticleEdit.tsx
+++ b/src/frontend/pages/ArticleEdit.tsx
@@ -299,8 +299,8 @@ export function ArticleEdit({ filename, token, onNavigate }: ArticleEditProps) {
         </div>
       </div>
 
-      <div className="edit-metadata-row" style={{ display: 'flex', gap: '1rem', alignItems: 'center', marginBottom: '1rem' }}>
-        <div className="edit-metadata-item" style={{ flex: '0 0 auto' }}>
+      <div className="edit-options-row">
+        <div className="edit-metadata-item edit-options-item">
           <label className="public-toggle-label">
             <input
               type="checkbox"
@@ -315,7 +315,7 @@ export function ArticleEdit({ filename, token, onNavigate }: ArticleEditProps) {
 
       {!isNew && (
         <div className="edit-metadata-row-two-col">
-          <div className="public-sharing-section" style={{ margin: 0, height: '100%', boxSizing: 'border-box' }}>
+          <div className="public-sharing-section edit-public-sharing-section">
             <label className="public-toggle-label">
               <input
                 type="checkbox"
@@ -349,7 +349,7 @@ export function ArticleEdit({ filename, token, onNavigate }: ArticleEditProps) {
 
           <div className="edit-metadata-item">
             <label className="edit-label">Article Slug/Filename</label>
-            <div style={{ display: 'flex', gap: '8px', alignItems: 'center' }}>
+            <div className="edit-slug-row">
               <input
                 type="text"
                 value={filename}
@@ -357,15 +357,14 @@ export function ArticleEdit({ filename, token, onNavigate }: ArticleEditProps) {
                 className="edit-slug-input"
               />
               <button
-                className="button button-secondary"
+                className="button button-secondary edit-rename-button"
                 onClick={() => setShowRenameModal(true)}
                 title="Rename article slug/filename"
-                style={{ whiteSpace: 'nowrap' }}
               >
                 Rename Slug
               </button>
             </div>
-            <small style={{ color: 'var(--text-tertiary)', fontSize: '0.85em', marginTop: '4px', display: 'block' }}>
+            <small className="edit-slug-help">
               The slug is used as the filename and in URLs. Must be unique.
             </small>
           </div>

--- a/src/frontend/styles/main.css
+++ b/src/frontend/styles/main.css
@@ -877,7 +877,7 @@ body {
 
 .edit-metadata-row-two-col {
   display: grid;
-  grid-template-columns: 1fr 1fr;
+  grid-template-columns: minmax(0, 1.15fr) minmax(0, 1fr);
   gap: 1.5rem;
   margin-bottom: 1.5rem;
   align-items: flex-start;
@@ -888,6 +888,41 @@ body {
   flex-direction: column;
 }
 
+
+.edit-options-row {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+
+.edit-options-item {
+  flex: 0 0 auto;
+}
+
+.edit-public-sharing-section {
+  margin: 0;
+  height: 100%;
+  box-sizing: border-box;
+  align-content: flex-start;
+}
+
+.edit-slug-row {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.edit-rename-button {
+  white-space: nowrap;
+}
+
+.edit-slug-help {
+  color: var(--text-tertiary);
+  font-size: 0.85em;
+  margin-top: 0.25rem;
+  display: block;
+}
 .edit-container {
   display: grid;
   grid-template-columns: 1fr 1fr;
@@ -1075,13 +1110,20 @@ body {
 
   .article-actions {
     width: 100%;
-    gap: 0.25rem;
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 0.5rem;
   }
 
   .article-actions .button {
-    flex: 1;
-    padding: 0.4rem 0.6rem;
-    font-size: 0.8rem;
+    width: 100%;
+    min-height: 2.4rem;
+    padding: 0.55rem 0.6rem;
+    font-size: 0.88rem;
+  }
+
+  .article-actions .button-primary {
+    grid-column: 1 / -1;
   }
 
   .edit-metadata-row {
@@ -1096,6 +1138,29 @@ body {
 
   .edit-container {
     grid-template-columns: 1fr;
+  }
+
+  .edit-options-row {
+    margin-bottom: 1rem;
+  }
+
+  .edit-slug-row {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .edit-rename-button {
+    width: 100%;
+  }
+
+  .share-link-pill {
+    width: 100%;
+    justify-content: space-between;
+  }
+
+  .edit-textarea,
+  .preview-content {
+    min-height: 360px;
   }
 
   .preview-section {


### PR DESCRIPTION
### Motivation
- Make the Article Edit page more usable on small screens by removing inline layout bits and introducing semantic classes so controls stack and size predictably on mobile while preserving a two-column desktop editor/preview layout. 
- Improve spacing and touch ergonomics for metadata, public-sharing, and slug rename controls to reduce cramped UI on phones.

### Description
- Replaced inline layout styles in `src/frontend/pages/ArticleEdit.tsx` with semantic CSS classes (`edit-options-row`, `edit-public-sharing-section`, `edit-slug-row`, `edit-rename-button`, `edit-slug-help`) and simplified DOM structure for metadata and slug controls. 
- Added responsive CSS in `src/frontend/styles/main.css` to rebalance metadata columns (`.edit-metadata-row-two-col`), convert header action buttons to a two-column grid on narrow viewports with a full-width primary `Save`, and reduce editor/preview min-heights on mobile. 
- Adjusted public-sharing and share-link pill styling so the sharing controls and rename button stack and fill available width on small screens while remaining side-by-side on desktop.

### Testing
- Ran `bun run precommit` which includes `tsc --noEmit` and the frontend build; TypeScript type check and frontend build passed (precommit succeeded). 
- Started the backend with `bun run dev:backend` to validate runtime wiring; the server process started but the health check returned degraded (`503`) due to missing DB configuration (`DB_PASSWORD`) in this environment. 
- Performed an automated HTTP smoke check with `curl -I` which returned `200 OK` for the frontend asset endpoint; an automated Playwright screenshot attempt timed out due to the environment/backend health constraints.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698cd1c64a188326b00b9602ba6bf571)