### PR TITLE
🛡️ Sentinel: [HIGH] Fix timing attack vulnerability in AUTH_TOKEN comparison

### DIFF
--- a/src/backend/middleware/auth.ts
+++ b/src/backend/middleware/auth.ts
@@ -1,3 +1,4 @@
+import { timingSafeEqual } from 'node:crypto';
 import { validateAccessToken, hasPermission, getTokenNameById, type TokenScope } from '../services/accessTokens.js';
 
 const AUTH_TOKEN = process.env.AUTH_TOKEN;
@@ -37,7 +38,20 @@ export function authenticateWeb(request: Request): boolean {
     return false;
   }
 
-  return token === AUTH_TOKEN;
+  try {
+    const a = Buffer.from(token, 'utf8');
+    const b = Buffer.from(AUTH_TOKEN!, 'utf8');
+    if (a.length !== b.length) {
+      // Prevent timing attacks by returning false when lengths don't match,
+      // but do a dummy comparison to avoid a length-based timing leak.
+      // timingSafeEqual throws if lengths are different.
+      timingSafeEqual(b, b);
+      return false;
+    }
+    return timingSafeEqual(a, b);
+  } catch (error) {
+    return false;
+  }
 }
 
 /**


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The `AUTH_TOKEN` verification was using simple string equality (`token === AUTH_TOKEN`), which allows for timing attacks. Standard string comparison operators return early when a character mismatch occurs, enabling an attacker to iteratively guess the correct token based on server response times.
🎯 Impact: An attacker could potentially deduce the valid administrative token, leading to an authorization bypass and administrative control over the application.
🔧 Fix: Replaced the comparison with `node:crypto.timingSafeEqual` to ensure a constant-time check. Included a safeguard that does a dummy `timingSafeEqual(b, b)` to mitigate length-discovery attacks if the lengths do not match. Caught unexpected parsing errors using a `try/catch` and defaulting to `false`.
✅ Verification: Ensure tests pass and login endpoints reject bad tokens exactly as before.

---
*PR created automatically by Jules for task [18312190788126353354](https://jules.google.com/task/18312190788126353354) started by @joelmnz*