### PR TITLE
Add optional OAuth support and per-token folder-regex restrictions; enforce in MCP and UI

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,7 @@
 # Essential Configuration - Only these variables are required for basic setup
 
-# Authentication token for all interfaces (REST API, MCP server, Web UI)
+# Authentication token for Web UI admin access and AUTH_TOKEN API fallback.
+# Optional when using OAuth or pre-created access tokens only.
 AUTH_TOKEN=your-secret-token-here
 
 # Database password (required for security)

--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "article-manager",

--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "article-manager",
@@ -8,6 +7,7 @@
         "@modelcontextprotocol/sdk": "^1.0.4",
         "@types/pg": "^8.16.0",
         "dompurify": "^3.2.6",
+        "jose": "^6.2.3",
         "markdownlint": "^0.38.0",
         "mermaid": "^11.12.0",
         "ollama": "^0.6.0",
@@ -456,6 +456,8 @@
     "is-promise": ["is-promise@4.0.0", "", {}, "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="],
 
     "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
+
+    "jose": ["jose@6.2.3", "", {}, "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw=="],
 
     "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 

--- a/docs/OAUTH_MCP_PLAN.md
+++ b/docs/OAUTH_MCP_PLAN.md
@@ -1,0 +1,239 @@
+# OAuth and ChatGPT MCP Support Plan
+
+## Confidence and decision
+
+Confidence is now about 95% that the right target is **optional OAuth/OIDC resource-server support for the existing `/mcp` endpoint**, backed by your self-hosted VoidAuth instance, while keeping the current local token system for scripts and non-ChatGPT clients.
+
+The app should **not** become an OAuth provider. VoidAuth should remain the identity provider, Cloudflare Tunnel should remain the HTTPS exposure layer, and MCP Markdown Manager should validate bearer tokens and enforce app-local article permissions.
+
+## Confirmed requirements
+
+- Deployment is a single-user homelab app exposed over HTTPS through Cloudflare Tunnel.
+- The primary OAuth use case is ChatGPT Pro developer-mode MCP access to `https://md.jknet.dev/mcp`.
+- VoidAuth is already hosted at a sibling subdomain such as `https://vauth.jknet.dev`.
+- Cloudflare Access is not currently blocking requests before they reach the app.
+- Public article routes must remain anonymously accessible.
+- The app-side target is to support ChatGPT read and write access, but only to article folder paths matching a configured regular expression such as `projects/.*-ai`. As of the latest OpenAI Help Center guidance reviewed for this plan, ChatGPT Pro custom MCP access is read/fetch-only while full MCP write/modify actions are limited to Business and Enterprise/Edu; this is an external product-plan constraint, not an app implementation constraint.
+- Audit attribution should use the simplest available identity: VoidAuth username/email for OAuth users, or token/client name for local tokens.
+- Existing scoped local tokens should remain available and should gain optional folder-regex restrictions.
+
+## VoidAuth findings that affect the plan
+
+VoidAuth mounts its OIDC issuer under `/oidc`, not at the domain root. Therefore the discovery URL should be:
+
+```text
+https://vauth.jknet.dev/oidc/.well-known/openid-configuration
+```
+
+not:
+
+```text
+https://vauth.jknet.dev/.well-known/openid-configuration
+```
+
+The VoidAuth source defines the provider issuer as `${APP_URL}/oidc`, and its own UI displays the well-known endpoint as `currentHost + '/oidc/.well-known/openid-configuration'`.
+
+VoidAuth client defaults include:
+
+- scopes: `openid offline_access profile email groups`
+- grant types: `authorization_code` and `refresh_token`
+- response type: `code`
+
+VoidAuth's admin UI supports these token endpoint auth methods:
+
+- `client_secret_basic`
+- `client_secret_post`
+- `client_secret_jwt`
+- `none` for public clients
+
+For ChatGPT MCP, the safest first configuration to try is a static VoidAuth OIDC app with:
+
+```text
+Issuer: https://vauth.jknet.dev/oidc
+Discovery: https://vauth.jknet.dev/oidc/.well-known/openid-configuration
+Scopes: openid profile email groups offline_access
+Grant types: authorization_code, refresh_token
+Response types: code
+Auth method: client_secret_basic or client_secret_post, depending on what ChatGPT accepts during connector setup
+```
+
+## Current codebase constraints
+
+The current REST auth middleware has a narrow `AuthContext` with `scope`, `tokenId`, and `tokenName`. It validates DB access tokens first, then falls back to `AUTH_TOKEN` and treats it as write scope.
+
+The current local token service only supports two scopes, `read-only` and `write`, and stores generated `sk-md-...` token strings in the database.
+
+The MCP server currently has its own bearer parsing and validates only local DB access tokens for MCP sessions. It filters tool visibility by `read-only` versus `write` scope, where write scope exposes all tools and read-only hides write tools.
+
+These constraints mean OAuth should be added through a shared auth service rather than separately in REST and MCP.
+
+## Readiness status
+
+The plan is ready to implement for the app-side foundation: shared auth, OAuth/OIDC token validation, local-token hardening, folder-regex authorization, and MCP/REST enforcement.
+
+The only remaining blocking product decision is external to this repository: whether ChatGPT write access is required from the first live rollout. Current OpenAI guidance says ChatGPT Pro users can connect MCP servers with read/fetch permissions, while full MCP write/modify actions are currently available only to Business and Enterprise/Edu. Therefore:
+
+- if you stay on ChatGPT Pro, implement the same secure foundation but validate the first ChatGPT rollout as read/fetch-only;
+- if write access from ChatGPT is mandatory immediately, plan for a Business or Enterprise/Edu workspace before treating end-to-end ChatGPT write support as complete;
+- either way, still implement server-side write authorization and folder-regex enforcement now, so the app is ready when the client/workspace supports write actions.
+
+
+## Target architecture
+
+```text
+ChatGPT Pro custom MCP connector
+  -> OAuth authorization with VoidAuth at https://vauth.jknet.dev/oidc
+  -> ChatGPT receives access token and refresh token if offline_access is granted
+  -> ChatGPT calls https://md.jknet.dev/mcp with Authorization: Bearer <access_token>
+  -> MCP Markdown Manager validates the token via VoidAuth discovery/JWKS or introspection
+  -> App maps claims/groups/client metadata to editor role plus folder regex restrictions
+  -> MCP tool handlers enforce tool scope and folder permissions before article operations
+```
+
+## Implementation phases
+
+### Phase 1: Shared auth model and local-token hardening
+
+1. Add a shared backend auth service used by both REST and MCP.
+2. Replace duplicate bearer parsing with one strict parser that only accepts `Authorization: Bearer <token>`.
+3. Expand auth context to include:
+   - `authType: 'local-token' | 'oauth' | 'auth-token'`
+   - `principalId`
+   - `principalName`
+   - `role: 'admin' | 'editor' | 'reader'`
+   - `scope: 'read-only' | 'write'`
+   - `folderRegex?: string`
+   - `tokenId?: number`
+   - `tokenName?: string`
+   - `groups?: string[]`
+4. Hash newly-created local access tokens at rest using HMAC-SHA-256 or SHA-256 with a server-side pepper.
+5. Keep existing plaintext tokens working during a migration window, but mark token hashing as the new storage format.
+
+### Phase 2: Folder-regex permission support for local tokens
+
+1. Add an optional `folder_regex` column to local access tokens.
+2. Extend token creation/editing to accept a folder regex.
+3. Validate regex syntax before saving.
+4. Treat missing `folder_regex` as unrestricted for backward compatibility.
+5. Enforce folder regex for all article read and write operations:
+   - article list/search results should hide articles outside the allowed folder pattern;
+   - read/update/delete should return forbidden or not found for disallowed folders;
+   - create should require the target folder to match the regex.
+
+The initial ChatGPT token-equivalent policy should be:
+
+```text
+role: editor
+scope: write
+folderRegex: ^projects/.*-ai(?:/.*)?$
+```
+
+This anchors the pattern so `old-projects/foo-ai` does not accidentally match when the intended root is `projects/`.
+
+### Phase 3: Optional OAuth/OIDC validation
+
+Add env-controlled OAuth validation without changing default deployments:
+
+```env
+OAUTH_ENABLED=false
+OAUTH_ISSUER_URL=https://vauth.jknet.dev/oidc
+OAUTH_AUDIENCE=mcp-markdown-manager
+OAUTH_CLIENT_ID=mcp-markdown-manager
+OAUTH_CLIENT_SECRET=
+OAUTH_REQUIRED_SCOPES=openid profile email offline_access
+OAUTH_USERNAME_CLAIM=preferred_username
+OAUTH_EMAIL_CLAIM=email
+OAUTH_GROUPS_CLAIM=groups
+OAUTH_DEFAULT_ROLE=editor
+OAUTH_DEFAULT_FOLDER_REGEX=^projects/.*-ai(?:/.*)?$
+```
+
+Validation order:
+
+1. Load discovery metadata from `OAUTH_ISSUER_URL/.well-known/openid-configuration`.
+2. Prefer JWT access-token validation with JWKS when tokens are JWTs.
+3. Fall back to token introspection only if VoidAuth issues opaque access tokens and advertises/supports introspection.
+4. Validate issuer, expiry, signature, and audience/client binding where available.
+5. Map `preferred_username`, `email`, `client_id`, or `sub` into `principalName` for audit attribution.
+
+### Phase 4: MCP integration for ChatGPT
+
+For ChatGPT Pro, verify read/fetch behavior first. Keep write-capable tools implemented and protected server-side, but do not consider ChatGPT write/modify fully verified unless the connector is tested from a plan/workspace that OpenAI currently allows to use full MCP write actions.
+
+1. Make `/mcp` use the shared auth service.
+2. Accept both local `sk-md-...` tokens and OAuth bearer tokens.
+3. Store the resulting auth context on the MCP session.
+4. Keep session token binding, but compare a stable auth fingerprint instead of storing raw bearer tokens long term.
+5. Continue exposing write tools only for editor/admin contexts.
+6. Enforce folder regex inside each tool handler, not just at tool listing time.
+7. Add or preserve obvious ChatGPT-friendly read tools such as list, search, and read/fetch.
+
+### Phase 5: REST API consistency
+
+1. Reuse the same auth service for REST API routes.
+2. Keep anonymous public article routes unchanged.
+3. Apply folder-regex restrictions consistently to REST list/search/read/create/update/delete operations.
+4. Make `AUTH_TOKEN` fallback configurable:
+
+```env
+AUTH_TOKEN_API_FALLBACK=true
+```
+
+Keep the current behavior initially, but document that disabling fallback is recommended after OAuth and local tokens are configured.
+
+### Phase 6: VoidAuth and ChatGPT setup notes
+
+In VoidAuth, create an OIDC app for ChatGPT/MCP Markdown Manager.
+
+Recommended starting settings:
+
+```text
+Client display name: MCP Markdown Manager
+Client ID: mcp-markdown-manager
+Scopes: openid profile email groups offline_access
+Response types: code
+Grant types: authorization_code, refresh_token
+Auth method: client_secret_basic first; if ChatGPT setup rejects it, try client_secret_post
+Groups: optional, e.g. mcp-markdown-chatgpt
+Skip consent: optional for your single-user homelab setup
+MFA required: your preference
+```
+
+In ChatGPT developer mode, configure the custom MCP connector with:
+
+```text
+MCP URL: https://md.jknet.dev/mcp
+OAuth issuer/discovery: https://vauth.jknet.dev/oidc/.well-known/openid-configuration
+Scopes: openid profile email groups offline_access
+```
+
+If ChatGPT has a callback URL to paste into VoidAuth, add that exact redirect URI to the VoidAuth OIDC app.
+
+## Key risks and mitigations
+
+- **Wrong discovery URL:** Use `/oidc/.well-known/openid-configuration`, because VoidAuth does not serve discovery at the domain root.
+- **Refresh-token loss:** Ensure `offline_access` is advertised and requested so ChatGPT can keep the connector authorized without frequent reauthentication.
+- **Over-broad write access:** Do not rely only on hiding tools. Enforce folder regex in article services and MCP handlers.
+- **ChatGPT plan limitation:** ChatGPT Pro currently supports custom MCP read/fetch access, but OpenAI's current guidance places full MCP write/modify support on Business and Enterprise/Edu; treat end-to-end Pro write support as unverified unless OpenAI changes this.
+- **Prompt-injection write risk:** Start with a narrow folder regex such as `^projects/.*-ai(?:/.*)?$`, and consider adding confirmation or separate high-risk tools later.
+- **Plaintext token leakage:** Hash local token secrets at rest before expanding auth surface area.
+- **Cloudflare Access interference:** Since the tunnel currently exposes the app without Access login, ChatGPT can reach `/mcp`. If Cloudflare Access is enabled later, exempt `/mcp` or ensure ChatGPT can complete that auth layer.
+
+## Out of scope for the first implementation
+
+- Building an OAuth/OIDC provider into MCP Markdown Manager.
+- Full multi-user web login.
+- Cookie sessions and CSRF changes for the frontend.
+- Per-folder permission management UI.
+- Dynamic Client Registration unless ChatGPT requires it and VoidAuth supports it sufficiently.
+- Replacing all local tokens with OAuth.
+
+## Open implementation questions
+
+These do not block implementation of the app-side foundation, but they do affect final rollout/verification:
+
+1. For the first live ChatGPT rollout, should the acceptance criteria be read/fetch-only on Pro, or should write support wait until a Business or Enterprise/Edu workspace is available?
+2. Does ChatGPT's connector setup accept VoidAuth's static client credentials flow with `client_secret_basic` or `client_secret_post` for an individual Pro custom connector?
+3. Are VoidAuth access tokens JWTs in your deployed version, or opaque tokens requiring introspection?
+4. What exact redirect URI does ChatGPT provide for the OAuth connector setup?
+5. Should folder-regex mismatches return `403 Forbidden` or be hidden as `404 Not Found` for article read/update/delete?

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "@modelcontextprotocol/sdk": "^1.0.4",
     "@types/pg": "^8.16.0",
     "dompurify": "^3.2.6",
+    "jose": "^6.2.3",
     "markdownlint": "^0.38.0",
     "mermaid": "^11.12.0",
     "ollama": "^0.6.0",

--- a/src/backend/mcp/handlers.ts
+++ b/src/backend/mcp/handlers.ts
@@ -17,12 +17,52 @@ import {
   validateArray,
   validateNumber,
 } from './validation';
+import type { AuthContext } from '../middleware/auth';
 
 const SEMANTIC_SEARCH_ENABLED = process.env.SEMANTIC_SEARCH_ENABLED?.toLowerCase() === 'true';
 const MCP_MULTI_SEARCH_LIMIT = Number.parseInt(process.env.MCP_MULTI_SEARCH_LIMIT ?? '10', 10);
 
 export interface McpHandlerContext {
   tokenName?: string;
+  auth?: AuthContext;
+}
+
+interface FolderScopedItem {
+  folder?: string;
+}
+
+function getFolderPattern(context?: McpHandlerContext): RegExp | null {
+  const folderRegex = context?.auth?.folderRegex;
+  if (!folderRegex) return null;
+  return new RegExp(folderRegex);
+}
+
+function normalizeFolderForAuth(folder?: string): string {
+  return !folder || folder === '/' ? '' : folder;
+}
+
+function isFolderAllowed(folder: string | undefined, context?: McpHandlerContext): boolean {
+  const pattern = getFolderPattern(context);
+  if (!pattern) return true;
+  return pattern.test(normalizeFolderForAuth(folder));
+}
+
+function assertFolderAllowed(folder: string | undefined, context?: McpHandlerContext): void {
+  if (!isFolderAllowed(folder, context)) {
+    throw new Error('Forbidden: this token is not allowed to access that folder');
+  }
+}
+
+function filterFolderScopedItems<T extends FolderScopedItem>(items: T[], context?: McpHandlerContext): T[] {
+  const pattern = getFolderPattern(context);
+  if (!pattern) return items;
+  return items.filter(item => pattern.test(normalizeFolderForAuth(item.folder)));
+}
+
+function assertSearchFolderProvidedWhenRestricted(folder: string | undefined, context?: McpHandlerContext): void {
+  if (context?.auth?.folderRegex && (folder === undefined || folder === null)) {
+    throw new Error('A folder parameter is required when this token has a folder restriction');
+  }
 }
 
 export const toolHandlers: Record<string, (args: any, context?: McpHandlerContext) => Promise<any>> = {
@@ -54,14 +94,16 @@ export const toolHandlers: Record<string, (args: any, context?: McpHandlerContex
       limit = limitValidation.sanitized || 100;
     }
     
-    const articles = await listArticles(sanitizedFolder, limit);
+    const articles = filterFolderScopedItems(await listArticles(sanitizedFolder, limit), context);
     return {
       content: [{ type: 'text', text: JSON.stringify(articles, null, 2) }],
     };
   },
 
   listFolders: async (args, context) => {
-    const folders = await getFolders();
+    const folders = getFolderPattern(context)
+      ? (await getFolders()).filter(folder => isFolderAllowed(folder, context))
+      : await getFolders();
     return {
       content: [{ type: 'text', text: JSON.stringify(folders, null, 2) }],
     };
@@ -86,7 +128,7 @@ export const toolHandlers: Record<string, (args: any, context?: McpHandlerContex
       sanitizedFolder = folderValidation.sanitized;
     }
     
-    const results = await searchArticles(queryValidation.sanitized!, sanitizedFolder);
+    const results = filterFolderScopedItems(await searchArticles(queryValidation.sanitized!, sanitizedFolder), context);
     return {
       content: [{ type: 'text', text: JSON.stringify(results, null, 2) }],
     };
@@ -120,9 +162,9 @@ export const toolHandlers: Record<string, (args: any, context?: McpHandlerContex
     const allResults = await Promise.all(
       titlesValidation.sanitized!.map((title: string) => searchArticles(title, sanitizedFolder))
     );
-    const uniqueResults = Array.from(
+    const uniqueResults = filterFolderScopedItems(Array.from(
       new Map(allResults.flat().map(article => [article.filename, article])).values()
-    );
+    ), context);
 
     return {
       content: [{ type: 'text', text: JSON.stringify(uniqueResults, null, 2) }],
@@ -164,6 +206,9 @@ export const toolHandlers: Record<string, (args: any, context?: McpHandlerContex
       sanitizedFolder = folderValidation.sanitized;
     }
     
+    assertSearchFolderProvidedWhenRestricted(sanitizedFolder, context);
+    assertFolderAllowed(sanitizedFolder, context);
+
     const results = await semanticSearch(queryValidation.sanitized!, resultCount, sanitizedFolder);
     return {
       content: [{ type: 'text', text: JSON.stringify(results, null, 2) }],
@@ -211,6 +256,9 @@ export const toolHandlers: Record<string, (args: any, context?: McpHandlerContex
       sanitizedFolder = folderValidation.sanitized;
     }
 
+    assertSearchFolderProvidedWhenRestricted(sanitizedFolder, context);
+    assertFolderAllowed(sanitizedFolder, context);
+
     const allResults = await Promise.all(
       queriesValidation.sanitized!.map((query: string) => semanticSearch(query, resultsPerQuery, sanitizedFolder))
     );
@@ -244,6 +292,7 @@ export const toolHandlers: Record<string, (args: any, context?: McpHandlerContex
     
     const article = await readArticle(filenameValidation.sanitized!);
     if (!article) throw new Error(`Article ${filenameValidation.sanitized} not found`);
+    assertFolderAllowed(article.folder, context);
     return {
       content: [{ type: 'text', text: JSON.stringify(article, null, 2) }],
     };
@@ -274,6 +323,8 @@ export const toolHandlers: Record<string, (args: any, context?: McpHandlerContex
       sanitizedFolder = folderValidation.sanitized;
     }
     
+    assertFolderAllowed(sanitizedFolder, context);
+
     const article = await createArticle(
       titleValidation.sanitized!,
       contentValidation.sanitized!,
@@ -318,6 +369,11 @@ export const toolHandlers: Record<string, (args: any, context?: McpHandlerContex
       sanitizedFolder = folderValidation.sanitized;
     }
     
+    const existingArticle = await readArticle(filenameValidation.sanitized!);
+    if (!existingArticle) throw new Error(`Article ${filenameValidation.sanitized} not found`);
+    assertFolderAllowed(existingArticle.folder, context);
+    assertFolderAllowed(sanitizedFolder ?? existingArticle.folder, context);
+
     const article = await updateArticle(
       filenameValidation.sanitized!,
       titleValidation.sanitized!,
@@ -341,6 +397,10 @@ export const toolHandlers: Record<string, (args: any, context?: McpHandlerContex
       throw new Error(filenameValidation.error);
     }
     
+    const existingArticle = await readArticle(filenameValidation.sanitized!);
+    if (!existingArticle) throw new Error(`Article ${filenameValidation.sanitized} not found`);
+    assertFolderAllowed(existingArticle.folder, context);
+
     await deleteArticle(filenameValidation.sanitized!);
     return {
       content: [{ type: 'text', text: JSON.stringify({ success: true, filename: filenameValidation.sanitized }, null, 2) }],

--- a/src/backend/mcp/server.ts
+++ b/src/backend/mcp/server.ts
@@ -17,7 +17,8 @@ import { logSecurityEvent } from './validation.ts';
 import { createRateLimiter, RateLimitPresets } from '../middleware/rateLimit';
 import { createRequestSizeValidator, RequestSizePresets } from '../middleware/requestSize';
 import { parseEnvInt } from '../utils/config';
-import { validateAccessToken, getTokenNameById, type TokenScope } from '../services/accessTokens.js';
+import { type TokenScope } from '../services/accessTokens.js';
+import { authenticate, getBearerToken, type AuthContext } from '../middleware/auth.js';
 
 
 type McpSessionEntry = {
@@ -26,6 +27,7 @@ type McpSessionEntry = {
   scope: TokenScope;
   tokenId?: number;
   tokenName?: string;
+  auth: AuthContext;
   createdAtMs: number;
   lastSeenAtMs: number;
   ip: string;
@@ -52,41 +54,6 @@ const MCP_MAX_REQUEST_SIZE_BYTES = parseEnvInt(process.env.MCP_MAX_REQUEST_SIZE_
 
 // Session management for HTTP transport
 const sessions: Record<string, McpSessionEntry> = {};
-
-function getBearerToken(request: Request): string | null {
-  const authHeader = request.headers.get('Authorization');
-  if (!authHeader) return null;
-
-  const match = authHeader.match(/^Bearer\s+(.+)$/i);
-  if (!match) return null;
-
-  const token = match[1].trim();
-  return token ? token : null;
-}
-
-async function isAuthorizedToken(token: string | null): Promise<{ valid: boolean; scope?: TokenScope; tokenId?: number; tokenName?: string }> {
-  if (!token) return { valid: false };
-
-  const validation = await validateAccessToken(token);
-  
-  if (!validation.valid || !validation.scope) {
-    return { valid: false };
-  }
-
-  // Get token name for tracking
-  let tokenName;
-  if (validation.tokenId) {
-    const name = await getTokenNameById(validation.tokenId);
-    tokenName = name || undefined;
-  }
-
-  return {
-    valid: validation.valid,
-    scope: validation.scope,
-    tokenId: validation.tokenId,
-    tokenName,
-  };
-}
 
 function getClientIp(request: Request): string {
   const forwardedFor = request.headers.get('x-forwarded-for');
@@ -161,9 +128,9 @@ const mcpSizeValidator = createRequestSizeValidator({
 
 async function getAuthorizedSession(request: Request, sessionId: string | null): Promise<{ entry: McpSessionEntry; sessionId: string } | Response> {
   const token = getBearerToken(request);
-  const authResult = await isAuthorizedToken(token);
+  const authResult = await authenticate(request);
 
-  if (!authResult.valid) {
+  if (!token || !authResult) {
     return new Response(JSON.stringify({ error: 'Unauthorized' }), {
       status: 401,
       headers: { 'Content-Type': 'application/json' },
@@ -240,7 +207,7 @@ function getToolsForScope(scope: TokenScope, allTools: any[]): any[] {
 }
 
 // Create a configured MCP server instance with scope-based tool filtering
-function createConfiguredMCPServer(scope: TokenScope, tokenName?: string) {
+function createConfiguredMCPServer(scope: TokenScope, tokenName?: string, auth?: AuthContext) {
   const server = new Server(
     {
       name: 'mcp-markdown-manager',
@@ -425,7 +392,7 @@ function createConfiguredMCPServer(scope: TokenScope, tokenName?: string) {
         throw new Error(`Tool "${toolName}" requires write scope, but token has ${scope} scope`);
       }
 
-      const result = await handler(request.params.arguments, { tokenName });
+      const result = await handler(request.params.arguments, { tokenName, auth });
 
       loggingService.logPerformanceMetric(`mcp_tool_${toolName}`, Date.now() - startTime, {
         metadata: { success: true }
@@ -457,15 +424,15 @@ function isInitializeRequest(body: any): boolean {
 
 export async function handleMCPPostRequest(request: Request): Promise<Response> {
   const token = getBearerToken(request);
-  const authResult = await isAuthorizedToken(token);
+  const authResult = await authenticate(request);
 
-  if (!authResult.valid || !authResult.scope) {
+  if (!token || !authResult) {
     return new Response(JSON.stringify({ error: 'Unauthorized' }), { status: 401, headers: { 'Content-Type': 'application/json' } });
   }
 
   const tokenScope = authResult.scope;
   const tokenId = authResult.tokenId;
-  const tokenName = authResult.tokenName;
+  const tokenName = authResult.tokenName || authResult.principalName;
 
   // Validate request size before processing
   const sizeCheck = await mcpSizeValidator(request);
@@ -497,6 +464,7 @@ export async function handleMCPPostRequest(request: Request): Promise<Response> 
         scope: tokenScope,
         tokenId,
         tokenName,
+        auth: authResult,
         createdAtMs: nowMs,
         lastSeenAtMs: nowMs,
         ip,
@@ -509,7 +477,7 @@ export async function handleMCPPostRequest(request: Request): Promise<Response> 
         delete sessions[newSessionId];
       };
 
-      const server = createConfiguredMCPServer(tokenScope, tokenName);
+      const server = createConfiguredMCPServer(tokenScope, tokenName, authResult);
       await server.connect(transport);
 
       loggingService.log(LogLevel.INFO, LogCategory.TASK_LIFECYCLE, `New MCP session initialized: ${newSessionId}`, {

--- a/src/backend/middleware/auth.ts
+++ b/src/backend/middleware/auth.ts
@@ -3,10 +3,6 @@ import { authenticateOAuthToken, type OAuthRole } from '../services/oauth.js';
 
 const AUTH_TOKEN = process.env.AUTH_TOKEN;
 
-if (!AUTH_TOKEN) {
-  throw new Error('AUTH_TOKEN environment variable is required');
-}
-
 export type AuthType = 'local-token' | 'oauth' | 'auth-token';
 
 export interface AuthContext {
@@ -45,6 +41,10 @@ export function getBearerToken(request: Request): string | null {
  * This is ONLY used for web UI login validation
  */
 export function authenticateWeb(request: Request): boolean {
+  if (!AUTH_TOKEN) {
+    return false;
+  }
+
   const token = getBearerToken(request);
 
   if (!token) {
@@ -162,6 +162,15 @@ export async function requireAuth(
   requiredScope?: TokenScope,
   useWebAuth: boolean = false
 ): Promise<{ error: Response } | { auth: AuthContext }> {
+  if (useWebAuth && !AUTH_TOKEN) {
+    return {
+      error: new Response(JSON.stringify({ error: 'Web authentication is unavailable because AUTH_TOKEN is not configured' }), {
+        status: 503,
+        headers: { 'Content-Type': 'application/json' }
+      })
+    };
+  }
+
   const authContext = await authenticate(request, useWebAuth);
 
   if (!authContext) {

--- a/src/backend/middleware/auth.ts
+++ b/src/backend/middleware/auth.ts
@@ -1,4 +1,5 @@
 import { validateAccessToken, hasPermission, getTokenNameById, type TokenScope } from '../services/accessTokens.js';
+import { authenticateOAuthToken, type OAuthRole } from '../services/oauth.js';
 
 const AUTH_TOKEN = process.env.AUTH_TOKEN;
 
@@ -6,23 +7,36 @@ if (!AUTH_TOKEN) {
   throw new Error('AUTH_TOKEN environment variable is required');
 }
 
+export type AuthType = 'local-token' | 'oauth' | 'auth-token';
+
 export interface AuthContext {
+  authType: AuthType;
   scope: TokenScope;
+  role: OAuthRole;
+  principalId: string;
+  principalName: string;
   tokenId?: number;
   tokenName?: string;
+  folderRegex?: string;
+  groups?: string[];
 }
 
 /**
- * Extract Bearer token from Authorization header
+ * Extract a token from a strict Authorization: Bearer <token> header.
  */
-function getBearerToken(request: Request): string | null {
+export function getBearerToken(request: Request): string | null {
   const authHeader = request.headers.get('Authorization');
 
   if (!authHeader) {
     return null;
   }
 
-  const token = authHeader.replace('Bearer ', '').trim();
+  const match = authHeader.match(/^Bearer\s+(.+)$/i);
+  if (!match) {
+    return null;
+  }
+
+  const token = match[1].trim();
   return token || null;
 }
 
@@ -65,43 +79,74 @@ export async function authenticateAccessToken(request: Request): Promise<AuthCon
     tokenName = name || undefined;
   }
 
+  const principalName = tokenName || `token-${validation.tokenId ?? 'unknown'}`;
+
   return {
+    authType: 'local-token',
     scope: validation.scope,
+    role: validation.scope === 'write' ? 'editor' : 'reader',
+    principalId: validation.tokenId ? `token:${validation.tokenId}` : principalName,
+    principalName,
     tokenId: validation.tokenId,
     tokenName,
+    folderRegex: validation.folderRegex,
   };
 }
 
 /**
- * Combined authentication: checks both web auth and access tokens
- * For web-only endpoints (token management), pass useWebAuth=true to ONLY accept AUTH_TOKEN
- * For API/MCP endpoints, this accepts BOTH access tokens and AUTH_TOKEN for flexibility
+ * Authenticate using an OAuth/OIDC access token.
+ */
+export async function authenticateOAuth(request: Request): Promise<AuthContext | null> {
+  const token = getBearerToken(request);
+
+  if (!token) {
+    return null;
+  }
+
+  return authenticateOAuthToken(token);
+}
+
+function createAuthTokenContext(): AuthContext {
+  return {
+    authType: 'auth-token',
+    scope: 'write',
+    role: 'admin',
+    principalId: 'auth-token:admin',
+    principalName: 'admin',
+    tokenName: 'admin',
+  };
+}
+
+/**
+ * Combined authentication: checks web auth, access tokens, and optional OAuth tokens.
+ * For web-only endpoints (token management), pass useWebAuth=true to ONLY accept AUTH_TOKEN.
+ * For API/MCP endpoints, this accepts access tokens, OAuth tokens when enabled, and AUTH_TOKEN for compatibility.
  */
 export async function authenticate(request: Request, useWebAuth: boolean = false): Promise<AuthContext | null> {
   if (useWebAuth) {
     // Web-only mode: check AUTH_TOKEN env var ONLY
     const isValid = authenticateWeb(request);
     if (isValid) {
-      // Web auth always has write scope and uses "admin" as token name
-      return { scope: 'write', tokenName: 'admin' };
+      return createAuthTokenContext();
     }
     return null;
   }
 
-  // API/MCP mode: Try access token first, then fall back to AUTH_TOKEN
-  // This allows both web UI (using AUTH_TOKEN) and external APIs (using access tokens) to work
-
-  // First, try access token from database
+  // API/MCP mode: Try local access token first, then optional OAuth, then AUTH_TOKEN fallback.
   const accessTokenAuth = await authenticateAccessToken(request);
   if (accessTokenAuth) {
     return accessTokenAuth;
   }
 
+  const oauthAuth = await authenticateOAuth(request);
+  if (oauthAuth) {
+    return oauthAuth;
+  }
+
   // Fall back to AUTH_TOKEN for web UI compatibility
   const isWebAuth = authenticateWeb(request);
   if (isWebAuth) {
-    // AUTH_TOKEN always has write scope and uses "admin" as token name
-    return { scope: 'write', tokenName: 'admin' };
+    return createAuthTokenContext();
   }
 
   return null;

--- a/src/backend/middleware/auth.ts
+++ b/src/backend/middleware/auth.ts
@@ -164,8 +164,8 @@ export async function requireAuth(
 ): Promise<{ error: Response } | { auth: AuthContext }> {
   if (useWebAuth && !AUTH_TOKEN) {
     return {
-      error: new Response(JSON.stringify({ error: 'Web authentication is unavailable because AUTH_TOKEN is not configured' }), {
-        status: 503,
+      error: new Response(JSON.stringify({ error: 'Web UI authentication requires AUTH_TOKEN to be configured' }), {
+        status: 501,
         headers: { 'Content-Type': 'application/json' }
       })
     };

--- a/src/backend/routes/api.ts
+++ b/src/backend/routes/api.ts
@@ -260,9 +260,12 @@ export async function handleApiRequest(request: Request): Promise<Response> {
 
       try {
         const body = await request.json();
-        const { name, scope, folderRegex } = body;
+        const payload = body && typeof body === 'object' ? body as Record<string, unknown> : {};
+        const name = typeof payload.name === 'string' ? payload.name : '';
+        const scope = payload.scope;
+        const folderRegex = payload.folderRegex;
 
-        if (!name || !name.trim()) {
+        if (!name.trim()) {
           return new Response(JSON.stringify({ error: 'Token name is required' }), {
             status: 400,
             headers: { 'Content-Type': 'application/json' }
@@ -271,6 +274,13 @@ export async function handleApiRequest(request: Request): Promise<Response> {
 
         if (scope !== 'read-only' && scope !== 'write') {
           return new Response(JSON.stringify({ error: 'Scope must be either "read-only" or "write"' }), {
+            status: 400,
+            headers: { 'Content-Type': 'application/json' }
+          });
+        }
+
+        if (folderRegex !== undefined && folderRegex !== null && typeof folderRegex !== 'string') {
+          return new Response(JSON.stringify({ error: 'Folder restriction must be a string' }), {
             status: 400,
             headers: { 'Content-Type': 'application/json' }
           });

--- a/src/backend/routes/api.ts
+++ b/src/backend/routes/api.ts
@@ -260,7 +260,7 @@ export async function handleApiRequest(request: Request): Promise<Response> {
 
       try {
         const body = await request.json();
-        const { name, scope } = body;
+        const { name, scope, folderRegex } = body;
 
         if (!name || !name.trim()) {
           return new Response(JSON.stringify({ error: 'Token name is required' }), {
@@ -276,7 +276,7 @@ export async function handleApiRequest(request: Request): Promise<Response> {
           });
         }
 
-        const token = await createAccessToken(name, scope as TokenScope);
+        const token = await createAccessToken(name, scope as TokenScope, folderRegex);
         return new Response(JSON.stringify(token), {
           status: 201,
           headers: { 'Content-Type': 'application/json' }

--- a/src/backend/server.ts
+++ b/src/backend/server.ts
@@ -390,7 +390,7 @@ console.log('🚀 MCP Markdown Manager Server Started');
 console.log('=====================================');
 console.log(`📡 Server: http://localhost:${PORT}`);
 console.log(`🗄️  Database: PostgreSQL`);
-console.log(`🔒 Authentication: ${process.env.AUTH_TOKEN ? 'Enabled' : 'MISSING - Set AUTH_TOKEN!'}`);
+console.log(`🔒 Authentication: ${process.env.AUTH_TOKEN ? 'AUTH_TOKEN enabled' : 'AUTH_TOKEN not configured (OAuth/access tokens only)'}`);
 console.log(`🤖 MCP Server: ${MCP_SERVER_ENABLED ? 'Enabled at /mcp' : 'Disabled'}`);
 
 // Embedding queue configuration logging

--- a/src/backend/services/accessTokens.ts
+++ b/src/backend/services/accessTokens.ts
@@ -11,6 +11,7 @@ export interface AccessToken {
   scope: TokenScope;
   created_at: Date;
   last_used_at: Date | null;
+  folder_regex: string | null;
 }
 
 export interface AccessTokenInfo {
@@ -20,12 +21,14 @@ export interface AccessTokenInfo {
   created_at: Date;
   last_used_at: Date | null;
   masked_token: string;
+  folder_regex: string | null;
 }
 
 export interface TokenValidationResult {
   valid: boolean;
   scope?: TokenScope;
   tokenId?: number;
+  folderRegex?: string;
 }
 
 /**
@@ -50,10 +53,29 @@ function maskToken(token: string): string {
   return `sk-md-****...${last4}`;
 }
 
+
+function validateFolderRegex(folderRegex?: string | null): string | null {
+  const trimmed = folderRegex?.trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  try {
+    new RegExp(trimmed);
+    return trimmed;
+  } catch (error) {
+    throw new DatabaseServiceError(
+      DatabaseErrorType.VALIDATION_ERROR,
+      `Invalid folder regex: ${error instanceof Error ? error.message : 'Unknown error'}`,
+      'Folder restriction must be a valid regular expression'
+    );
+  }
+}
+
 /**
  * Create a new access token
  */
-export async function createAccessToken(name: string, scope: TokenScope): Promise<AccessToken> {
+export async function createAccessToken(name: string, scope: TokenScope, folderRegex?: string | null): Promise<AccessToken> {
   if (!name || !name.trim()) {
     throw new DatabaseServiceError(
       DatabaseErrorType.VALIDATION_ERROR,
@@ -71,13 +93,14 @@ export async function createAccessToken(name: string, scope: TokenScope): Promis
   }
 
   const token = generateAccessToken();
+  const validatedFolderRegex = validateFolderRegex(folderRegex);
 
   try {
     const result = await database.query<AccessToken>(
-      `INSERT INTO access_tokens (token, name, scope)
-       VALUES ($1, $2, $3)
-       RETURNING id, token, name, scope, created_at, last_used_at`,
-      [token, name.trim(), scope]
+      `INSERT INTO access_tokens (token, name, scope, folder_regex)
+       VALUES ($1, $2, $3, $4)
+       RETURNING id, token, name, scope, folder_regex, created_at, last_used_at`,
+      [token, name.trim(), scope, validatedFolderRegex]
     );
 
     if (result.rows.length === 0) {
@@ -107,7 +130,7 @@ export async function createAccessToken(name: string, scope: TokenScope): Promis
 export async function listAccessTokens(): Promise<AccessTokenInfo[]> {
   try {
     const result = await database.query<AccessToken>(
-      `SELECT id, token, name, scope, created_at, last_used_at
+      `SELECT id, token, name, scope, folder_regex, created_at, last_used_at
        FROM access_tokens
        ORDER BY created_at DESC`
     );
@@ -119,6 +142,7 @@ export async function listAccessTokens(): Promise<AccessTokenInfo[]> {
       created_at: row.created_at,
       last_used_at: row.last_used_at,
       masked_token: maskToken(row.token),
+      folder_regex: row.folder_regex,
     }));
   } catch (error) {
     throw new DatabaseServiceError(
@@ -135,7 +159,7 @@ export async function listAccessTokens(): Promise<AccessTokenInfo[]> {
 export async function getAccessToken(token: string): Promise<AccessToken | null> {
   try {
     const result = await database.query<AccessToken>(
-      `SELECT id, token, name, scope, created_at, last_used_at
+      `SELECT id, token, name, scope, folder_regex, created_at, last_used_at
        FROM access_tokens
        WHERE token = $1`,
       [token]
@@ -218,7 +242,7 @@ export async function validateAccessToken(token: string): Promise<TokenValidatio
 
   try {
     const result = await database.query<AccessToken>(
-      `SELECT id, scope, last_used_at
+      `SELECT id, scope, folder_regex, last_used_at
        FROM access_tokens
        WHERE token = $1`,
       [token]
@@ -242,6 +266,7 @@ export async function validateAccessToken(token: string): Promise<TokenValidatio
       valid: true,
       scope: tokenData.scope,
       tokenId: tokenData.id,
+      folderRegex: tokenData.folder_regex || undefined,
     };
   } catch (error) {
     console.error('Token validation error:', error);

--- a/src/backend/services/accessTokens.ts
+++ b/src/backend/services/accessTokens.ts
@@ -54,8 +54,20 @@ function maskToken(token: string): string {
 }
 
 
-function validateFolderRegex(folderRegex?: string | null): string | null {
-  const trimmed = folderRegex?.trim();
+function validateFolderRegex(folderRegex?: unknown): string | null {
+  if (folderRegex === undefined || folderRegex === null) {
+    return null;
+  }
+
+  if (typeof folderRegex !== 'string') {
+    throw new DatabaseServiceError(
+      DatabaseErrorType.VALIDATION_ERROR,
+      `Invalid folder regex type: ${typeof folderRegex}`,
+      'Folder restriction must be a string'
+    );
+  }
+
+  const trimmed = folderRegex.trim();
   if (!trimmed) {
     return null;
   }

--- a/src/backend/services/oauth.ts
+++ b/src/backend/services/oauth.ts
@@ -165,7 +165,7 @@ async function getDiscoveryMetadata(config: OAuthConfig): Promise<OidcDiscoveryM
   }
 
   const metadata = await response.json() as OidcDiscoveryMetadata;
-  if (metadata.issuer !== config.issuerUrl) {
+  if (normalizeUrl(metadata.issuer) !== config.issuerUrl) {
     throw new Error(`OIDC issuer mismatch: expected ${config.issuerUrl}, got ${metadata.issuer}`);
   }
 

--- a/src/backend/services/oauth.ts
+++ b/src/backend/services/oauth.ts
@@ -1,0 +1,260 @@
+import { Buffer } from 'buffer';
+import { createRemoteJWKSet, jwtVerify, type JWTPayload } from 'jose';
+import type { TokenScope } from './accessTokens.js';
+
+export type OAuthRole = 'admin' | 'editor' | 'reader';
+
+export interface OAuthAuthContext {
+  authType: 'oauth';
+  scope: TokenScope;
+  role: OAuthRole;
+  principalId: string;
+  principalName: string;
+  folderRegex?: string;
+  groups?: string[];
+}
+
+interface OidcDiscoveryMetadata {
+  issuer: string;
+  jwks_uri?: string;
+  introspection_endpoint?: string;
+}
+
+interface OAuthConfig {
+  enabled: boolean;
+  issuerUrl: string;
+  audience?: string;
+  clientId?: string;
+  clientSecret?: string;
+  requiredScopes: string[];
+  usernameClaim: string;
+  emailClaim: string;
+  groupsClaim: string;
+  defaultRole: OAuthRole;
+  defaultFolderRegex?: string;
+}
+
+let discoveryCache: OidcDiscoveryMetadata | null = null;
+let jwksCache: ReturnType<typeof createRemoteJWKSet> | null = null;
+let jwksUriCache: string | null = null;
+
+function normalizeUrl(url: string): string {
+  return url.replace(/\/+$/, '');
+}
+
+function parseBoolean(value: string | undefined): boolean {
+  return value?.toLowerCase() === 'true';
+}
+
+function parseRequiredScopes(value: string | undefined): string[] {
+  if (!value) return [];
+  return value
+    .split(/[\s,]+/)
+    .map(scope => scope.trim())
+    .filter(Boolean);
+}
+
+function parseRole(value: string | undefined): OAuthRole {
+  if (value === 'admin' || value === 'editor' || value === 'reader') {
+    return value;
+  }
+  return 'editor';
+}
+
+function getConfig(): OAuthConfig {
+  return {
+    enabled: parseBoolean(process.env.OAUTH_ENABLED),
+    issuerUrl: normalizeUrl(process.env.OAUTH_ISSUER_URL || ''),
+    audience: process.env.OAUTH_AUDIENCE?.trim() || undefined,
+    clientId: process.env.OAUTH_CLIENT_ID?.trim() || undefined,
+    clientSecret: process.env.OAUTH_CLIENT_SECRET?.trim() || undefined,
+    requiredScopes: parseRequiredScopes(process.env.OAUTH_REQUIRED_SCOPES),
+    usernameClaim: process.env.OAUTH_USERNAME_CLAIM || 'preferred_username',
+    emailClaim: process.env.OAUTH_EMAIL_CLAIM || 'email',
+    groupsClaim: process.env.OAUTH_GROUPS_CLAIM || 'groups',
+    defaultRole: parseRole(process.env.OAUTH_DEFAULT_ROLE),
+    defaultFolderRegex: process.env.OAUTH_DEFAULT_FOLDER_REGEX?.trim() || undefined,
+  };
+}
+
+function isJwt(token: string): boolean {
+  return token.split('.').length === 3;
+}
+
+function getClaimString(payload: JWTPayload | Record<string, unknown>, claimName: string): string | undefined {
+  const value = payload[claimName];
+  return typeof value === 'string' && value.trim() ? value : undefined;
+}
+
+function getClaimStringArray(payload: JWTPayload | Record<string, unknown>, claimName: string): string[] | undefined {
+  const value = payload[claimName];
+  if (Array.isArray(value)) {
+    return value.filter((item): item is string => typeof item === 'string' && item.trim().length > 0);
+  }
+  if (typeof value === 'string' && value.trim()) {
+    return value.split(/[\s,]+/).filter(Boolean);
+  }
+  return undefined;
+}
+
+function getTokenScopes(payload: JWTPayload | Record<string, unknown>): string[] {
+  const scope = getClaimString(payload, 'scope');
+  if (scope) return scope.split(/[\s,]+/).filter(Boolean);
+
+  const scp = getClaimStringArray(payload, 'scp');
+  return scp || [];
+}
+
+function hasRequiredScopes(payload: JWTPayload | Record<string, unknown>, requiredScopes: string[]): boolean {
+  if (requiredScopes.length === 0) return true;
+  const tokenScopes = new Set(getTokenScopes(payload));
+  return requiredScopes.every(scope => tokenScopes.has(scope));
+}
+
+function roleToScope(role: OAuthRole): TokenScope {
+  return role === 'reader' ? 'read-only' : 'write';
+}
+
+function getPrincipalName(payload: JWTPayload | Record<string, unknown>, config: OAuthConfig): string {
+  return (
+    getClaimString(payload, config.usernameClaim) ||
+    getClaimString(payload, config.emailClaim) ||
+    getClaimString(payload, 'client_id') ||
+    getClaimString(payload, 'sub') ||
+    'oauth-user'
+  );
+}
+
+function validateFolderRegex(folderRegex: string | undefined): string | undefined {
+  if (!folderRegex) return undefined;
+  try {
+    new RegExp(folderRegex);
+    return folderRegex;
+  } catch (error) {
+    console.warn(`Ignoring invalid OAUTH_DEFAULT_FOLDER_REGEX: ${error instanceof Error ? error.message : 'Unknown error'}`);
+    return undefined;
+  }
+}
+
+function buildAuthContext(payload: JWTPayload | Record<string, unknown>, config: OAuthConfig): OAuthAuthContext | null {
+  if (!hasRequiredScopes(payload, config.requiredScopes)) {
+    return null;
+  }
+
+  const principalId = getClaimString(payload, 'sub') || getClaimString(payload, 'client_id') || getPrincipalName(payload, config);
+  const principalName = getPrincipalName(payload, config);
+
+  return {
+    authType: 'oauth',
+    scope: roleToScope(config.defaultRole),
+    role: config.defaultRole,
+    principalId,
+    principalName,
+    folderRegex: validateFolderRegex(config.defaultFolderRegex),
+    groups: getClaimStringArray(payload, config.groupsClaim),
+  };
+}
+
+async function getDiscoveryMetadata(config: OAuthConfig): Promise<OidcDiscoveryMetadata | null> {
+  if (!config.issuerUrl) return null;
+  if (discoveryCache) return discoveryCache;
+
+  const response = await fetch(`${config.issuerUrl}/.well-known/openid-configuration`);
+  if (!response.ok) {
+    throw new Error(`OIDC discovery failed with status ${response.status}`);
+  }
+
+  const metadata = await response.json() as OidcDiscoveryMetadata;
+  if (metadata.issuer !== config.issuerUrl) {
+    throw new Error(`OIDC issuer mismatch: expected ${config.issuerUrl}, got ${metadata.issuer}`);
+  }
+
+  discoveryCache = metadata;
+  return discoveryCache;
+}
+
+async function validateJwtAccessToken(token: string, config: OAuthConfig, metadata: OidcDiscoveryMetadata): Promise<OAuthAuthContext | null> {
+  if (!metadata.jwks_uri) return null;
+
+  if (!jwksCache || jwksUriCache !== metadata.jwks_uri) {
+    jwksCache = createRemoteJWKSet(new URL(metadata.jwks_uri));
+    jwksUriCache = metadata.jwks_uri;
+  }
+
+  const verifyOptions = config.audience
+    ? { issuer: config.issuerUrl, audience: config.audience }
+    : { issuer: config.issuerUrl };
+  const { payload } = await jwtVerify(token, jwksCache, verifyOptions);
+  return buildAuthContext(payload, config);
+}
+
+function getIntrospectionHeaders(config: OAuthConfig): Headers {
+  const headers = new Headers({ 'Content-Type': 'application/x-www-form-urlencoded' });
+
+  if (config.clientId && config.clientSecret) {
+    const credentials = Buffer.from(`${config.clientId}:${config.clientSecret}`).toString('base64');
+    headers.set('Authorization', `Basic ${credentials}`);
+  }
+
+  return headers;
+}
+
+async function validateOpaqueAccessToken(token: string, config: OAuthConfig, metadata: OidcDiscoveryMetadata): Promise<OAuthAuthContext | null> {
+  if (!metadata.introspection_endpoint) return null;
+
+  const body = new URLSearchParams({ token });
+  if (config.clientId && !config.clientSecret) {
+    body.set('client_id', config.clientId);
+  }
+
+  const response = await fetch(metadata.introspection_endpoint, {
+    method: 'POST',
+    headers: getIntrospectionHeaders(config),
+    body,
+  });
+
+  if (!response.ok) {
+    return null;
+  }
+
+  const payload = await response.json() as Record<string, unknown>;
+  if (payload.active !== true) {
+    return null;
+  }
+
+  const issuer = getClaimString(payload, 'iss');
+  if (issuer && issuer !== config.issuerUrl) {
+    return null;
+  }
+
+  if (config.audience) {
+    const audiences = getClaimStringArray(payload, 'aud');
+    if (audiences && audiences.length > 0 && !audiences.includes(config.audience)) {
+      return null;
+    }
+  }
+
+  return buildAuthContext(payload, config);
+}
+
+export async function authenticateOAuthToken(token: string): Promise<OAuthAuthContext | null> {
+  const config = getConfig();
+  if (!config.enabled || !config.issuerUrl) {
+    return null;
+  }
+
+  try {
+    const metadata = await getDiscoveryMetadata(config);
+    if (!metadata) return null;
+
+    if (isJwt(token)) {
+      const jwtContext = await validateJwtAccessToken(token, config, metadata);
+      if (jwtContext) return jwtContext;
+    }
+
+    return await validateOpaqueAccessToken(token, config, metadata);
+  } catch (error) {
+    console.warn('OAuth token validation failed:', error instanceof Error ? error.message : error);
+    return null;
+  }
+}

--- a/src/backend/services/oauth.ts
+++ b/src/backend/services/oauth.ts
@@ -165,8 +165,9 @@ async function getDiscoveryMetadata(config: OAuthConfig): Promise<OidcDiscoveryM
   }
 
   const metadata = await response.json() as OidcDiscoveryMetadata;
-  if (normalizeUrl(metadata.issuer) !== config.issuerUrl) {
-    throw new Error(`OIDC issuer mismatch: expected ${config.issuerUrl}, got ${metadata.issuer}`);
+  const metadataIssuer = normalizeUrl(metadata.issuer);
+  if (metadataIssuer !== config.issuerUrl) {
+    throw new Error(`OIDC issuer mismatch: expected ${config.issuerUrl}, got ${metadataIssuer}`);
   }
 
   discoveryCache = metadata;

--- a/src/backend/services/schema.ts
+++ b/src/backend/services/schema.ts
@@ -24,6 +24,7 @@ export class SchemaService {
 
       // Update schema with new columns
       await this.addNoRagColumn();
+      await this.addAccessTokenFolderRegexColumn();
 
       // Create indexes for performance
       await this.createIndexes();
@@ -258,6 +259,7 @@ export class SchemaService {
         token VARCHAR(100) UNIQUE NOT NULL,
         name VARCHAR(255) NOT NULL,
         scope VARCHAR(20) NOT NULL CHECK (scope IN ('read-only', 'write')),
+        folder_regex TEXT,
         created_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
         last_used_at TIMESTAMP WITH TIME ZONE
       )
@@ -265,6 +267,22 @@ export class SchemaService {
 
     await database.query(createTableSQL);
     console.log('Access tokens table created/verified');
+  }
+
+
+  /**
+   * Add folder_regex column to access_tokens table if it doesn't exist
+   */
+  private async addAccessTokenFolderRegexColumn(): Promise<void> {
+    try {
+      await database.query(`
+        ALTER TABLE access_tokens
+        ADD COLUMN IF NOT EXISTS folder_regex TEXT
+      `);
+    } catch (error) {
+      console.warn('Failed to add folder_regex column to access_tokens:', error);
+      throw new Error(`Schema initialization failed: unable to add folder_regex column - ${error}`);
+    }
   }
 
   /**

--- a/src/frontend/pages/Settings.tsx
+++ b/src/frontend/pages/Settings.tsx
@@ -8,6 +8,7 @@ interface AccessToken {
   created_at: string;
   last_used_at: string | null;
   masked_token: string;
+  folder_regex: string | null;
 }
 
 interface NewTokenResult {
@@ -16,6 +17,7 @@ interface NewTokenResult {
   name: string;
   scope: string;
   created_at: string;
+  folder_regex: string | null;
 }
 
 interface SettingsProps {
@@ -29,6 +31,7 @@ export function Settings({ authToken, onNavigate }: SettingsProps) {
   const [error, setError] = useState<string | null>(null);
   const [newTokenName, setNewTokenName] = useState('');
   const [newTokenScope, setNewTokenScope] = useState<'read-only' | 'write'>('write');
+  const [newTokenFolderRegex, setNewTokenFolderRegex] = useState('');
   const [creating, setCreating] = useState(false);
   const [newlyCreatedToken, setNewlyCreatedToken] = useState<NewTokenResult | null>(null);
   const [visibleTokens, setVisibleTokens] = useState<Set<number>>(new Set());
@@ -74,7 +77,11 @@ export function Settings({ authToken, onNavigate }: SettingsProps) {
     try {
       const response = await apiClient.post(
         '/api/access-tokens',
-        { name: newTokenName.trim(), scope: newTokenScope },
+        {
+          name: newTokenName.trim(),
+          scope: newTokenScope,
+          folderRegex: newTokenFolderRegex.trim() || null,
+        },
         authToken
       );
 
@@ -87,6 +94,7 @@ export function Settings({ authToken, onNavigate }: SettingsProps) {
       setNewlyCreatedToken(newToken);
       setNewTokenName('');
       setNewTokenScope('write');
+      setNewTokenFolderRegex('');
       await loadTokens();
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to create token');
@@ -204,6 +212,21 @@ export function Settings({ authToken, onNavigate }: SettingsProps) {
               </small>
             </div>
 
+            <div className="form-group">
+              <label htmlFor="token-folder-regex">Folder Restriction (optional regex)</label>
+              <input
+                type="text"
+                id="token-folder-regex"
+                value={newTokenFolderRegex}
+                onChange={(e) => setNewTokenFolderRegex(e.target.value)}
+                placeholder="e.g., ^projects/.*-ai(?:/.*)?$"
+                disabled={creating}
+              />
+              <small className="form-help">
+                Leave blank for all folders. When set, MCP tools can only access matching article folders.
+              </small>
+            </div>
+
             <button type="submit" disabled={creating} className="create-button">
               {creating ? 'Generating...' : 'Generate Access Token'}
             </button>
@@ -223,6 +246,7 @@ export function Settings({ authToken, onNavigate }: SettingsProps) {
                   <th>Name</th>
                   <th>Scope</th>
                   <th>Token</th>
+                  <th>Folder Restriction</th>
                   <th>Created</th>
                   <th>Last Used</th>
                   <th>Actions</th>
@@ -241,6 +265,9 @@ export function Settings({ authToken, onNavigate }: SettingsProps) {
                       <code className="token-display">
                         {visibleTokens.has(t.id) ? t.masked_token : '••••••••••'}
                       </code>
+                    </td>
+                    <td className="token-value" data-label="Folder Restriction">
+                      {t.folder_regex ? <code className="token-display">{t.folder_regex}</code> : 'All folders'}
                     </td>
                     <td className="token-date" data-label="Created">{formatDate(t.created_at)}</td>
                     <td className="token-date" data-label="Last Used">
@@ -281,6 +308,10 @@ export function Settings({ authToken, onNavigate }: SettingsProps) {
                 <span className={`scope-badge scope-${newlyCreatedToken.scope}`}>
                   {newlyCreatedToken.scope === 'write' ? 'Write' : 'Read-Only'}
                 </span>
+              </div>
+              <div className="detail-row">
+                <label>Folder Restriction:</label>
+                <span>{newlyCreatedToken.folder_regex || 'All folders'}</span>
               </div>
               <div className="detail-row full-width">
                 <label>Token:</label>


### PR DESCRIPTION
### Motivation

- Introduce optional OAuth/OIDC validation for bearer tokens so external clients (e.g. ChatGPT MCP connectors) can authenticate against a configured identity provider.
- Add per-access-token folder restrictions so API/MCP tokens can be scoped to specific article folder patterns for safer delegated access.
- Unify authentication between REST and MCP paths so both can accept local tokens, the `AUTH_TOKEN` fallback, and optional OAuth tokens consistently.

### Description

- Add a new OAuth service (`src/backend/services/oauth.ts`) that validates JWTs via JWKS and falls back to token introspection, driven by environment variables such as `OAUTH_ENABLED` and `OAUTH_ISSUER_URL`, and map claims into an auth context.
- Extend the auth middleware (`src/backend/middleware/auth.ts`) with `AuthContext` and support for `authenticateAccessToken`, `authenticateOAuth`, and a unified `authenticate` flow that tries local tokens, then OAuth, then `AUTH_TOKEN` fallback.
- Add `folder_regex` column to `access_tokens` schema and migration (`src/backend/services/schema.ts`), and propagate the field through the access token service (`src/backend/services/accessTokens.ts`) including validation, CRUD, and token validation result.
- Enforce folder restrictions in MCP: pass `AuthContext` into MCP session entries and tool handlers (`src/backend/mcp/server.ts`, `src/backend/mcp/handlers.ts`) and apply checks/filters (`assertFolderAllowed`, `filterFolderScopedItems`, etc.) on list/search/read/create/update/delete and semantic search operations.
- Update REST API and frontend settings to create and display folder restrictions: `POST /api/access-tokens` accepts `folderRegex`, and `src/frontend/pages/Settings.tsx` adds the UI to set and show the restriction.
- Add `jose` dependency to `package.json` and `bun.lock` for JWT/JWKS handling, and include a new docs plan file `docs/OAUTH_MCP_PLAN.md` describing the design and deployment notes.

### Testing

- No automated tests were added or executed as part of this change set.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01beae93ec832685e2980386a19527)